### PR TITLE
34 discuss refactoring marching_squares.py to rely less on object state

### DIFF
--- a/marching_squares/marching_squares/__init__.py
+++ b/marching_squares/marching_squares/__init__.py
@@ -1,0 +1,1 @@
+from .marching_squares import MarchingSquares

--- a/marching_squares/marching_squares/marching_squares.py
+++ b/marching_squares/marching_squares/marching_squares.py
@@ -321,12 +321,12 @@ class MarchingSquares:
         plt.show()
         return shapes[0]
 
-    def run(self, file: str) -> None:
-        self.file = file
-
-        self._readfile()
-        self._otsu_segmentation()
-        self._point_array()
-        self._list_vectors()
-        self._vector_shapes()
-        self._show_coastline()
+    @staticmethod
+    def run(file: str, downsample_factor: float = 1) -> None:
+        
+        image = MarchingSquares._readfile(file, downsample_factor)
+        _, image = MarchingSquares._otsu_segmentation(image)
+        state_dict, x_len, y_len = MarchingSquares._point_array(image)
+        vectors = MarchingSquares._list_vectors(state_dict, x_len, y_len)
+        shapes = MarchingSquares._vector_shapes(vectors)
+        _ = MarchingSquares._show_coastline(image, shapes, x_len, y_len)

--- a/marching_squares/marching_squares/marching_squares.py
+++ b/marching_squares/marching_squares/marching_squares.py
@@ -2,7 +2,7 @@ import matplotlib.pyplot as plt  # This will import plotting module
 import numpy as np
 from numpy.typing import NDArray
 import cv2
-from typing import Any, cast, Optional
+from typing import Any, Optional
 
 
 # typedefs
@@ -107,7 +107,7 @@ class MarchingSquares:
         state: dict[_POINT, bool] = {tuple(point): True for point in black}
         state.update({tuple(point): False for point in white})
         sorted_dict: list[tuple[_POINT, bool]] = sorted(
-            state.items(), key=lambda x: self._sort_key(x[0])
+            state.items(), key=lambda x: MarchingSquares._sort_key(x[0])
         )
 
         return (dict(sorted_dict),  max(xblack + xwhite), max(yblack + ywhite))
@@ -330,3 +330,9 @@ class MarchingSquares:
         vectors = MarchingSquares._list_vectors(state_dict, x_len, y_len)
         shapes = MarchingSquares._vector_shapes(vectors)
         _ = MarchingSquares._show_coastline(image, shapes, x_len, y_len)
+
+
+import os
+
+print(os.path.dirname(__file__) + "/Aberdeenshire_S2_20220810_TCI.tif")
+MarchingSquares.run(os.path.dirname(__file__) + "/Aberdeenshire_S2_20220810_TCI.tif")

--- a/marching_squares/marching_squares/marching_squares.py
+++ b/marching_squares/marching_squares/marching_squares.py
@@ -73,27 +73,24 @@ class MarchingSquares:
         """
         return point[1] * 100 + point[0]
 
-    def _point_array(self) -> None:
+    @staticmethod
+    def _point_array(image: _NUMERIC_ARRAY) -> tuple[dict[tuple[_POINT, bool]], int, int]:
         """This extracts the points from the image and stores them in a dictionary with
         each point either corresponding to black or white. The coordinates are doubled
         and incresed by one as vector lines will be drawn halfway between these points.
         This can be changed to match the original resolution of the image, however
         vectors will then be made of floating point coordinates.
         """
-        if self.result_image is None:
-            raise ValueError(
-                "Cannot calculate point array when self.result_image is None"
-            )
 
         black_list: list[_POINT] = []
         white_list: list[_POINT] = []
 
-        x = self.result_image.shape[0] - 1
-        y = self.result_image.shape[1] - 1
+        x = image.shape[0] - 1
+        y = image.shape[1] - 1
 
         for i in range(x + 1):
             for j in range(y + 1):
-                if self.result_image[i][j] == 1:
+                if image[i][j] == 1:
                     black_list.append((j, x - i))
                 else:
                     white_list.append((j, x - i))
@@ -112,10 +109,8 @@ class MarchingSquares:
         sorted_dict: list[tuple[_POINT, bool]] = sorted(
             state.items(), key=lambda x: self._sort_key(x[0])
         )
-        self.state_dict = dict(sorted_dict)
 
-        self.x_len = max(xblack + xwhite)
-        self.y_len = max(yblack + ywhite)
+        return (dict(sorted_dict),  max(xblack + xwhite), max(yblack + ywhite))
 
     def _get_value(self, i: int, j: int) -> int:
         """Splitting the point array space into squares 1 pixel wide. These squares

--- a/marching_squares/marching_squares/marching_squares.py
+++ b/marching_squares/marching_squares/marching_squares.py
@@ -336,6 +336,3 @@ class MarchingSquares:
         vectors = MarchingSquares._list_vectors(state_dict, x_len, y_len)
         shapes = MarchingSquares._vector_shapes(vectors)
         _ = MarchingSquares._show_coastline(image, shapes, x_len, y_len)
-
-
-MarchingSquares.run("marching_squares/marching_squares/Aberdeenshire_S2_20220810_TCI.tif", 0.05)

--- a/marching_squares/marching_squares/marching_squares.py
+++ b/marching_squares/marching_squares/marching_squares.py
@@ -131,7 +131,8 @@ class MarchingSquares:
         D = int(state_dict[(i + 2, j + 2)])
         return A + B * 2 + C * 4 + D * 8
 
-    def _generate_edges(self, i: int, j: int, index: int) -> list[_VECTOR] | None:
+    @staticmethod
+    def _generate_edges(i: int, j: int, index: int) -> list[_VECTOR] | None:
         """Generates the line associated with the index of the square. This is done by
         outputting a start and end point for a line. Indexes of 6 and 9 are special in
         that two lines are created.

--- a/marching_squares/marching_squares/marching_squares.py
+++ b/marching_squares/marching_squares/marching_squares.py
@@ -47,7 +47,8 @@ class MarchingSquares:
         # distinguish between land and sea.
         return cv2.cvtColor(image_resized, cv2.COLOR_BGR2HSV)
 
-    def _otsu_segmentation(self) -> None:
+    @staticmethod
+    def _otsu_segmentation(image: _NUMERIC_ARRAY) -> tuple[float, _NUMERIC_ARRAY]:
         """Uses the Otsu segmentation method to distinguish between land and sea to
         extract the coastline vector. This will be later replaced by the UNET section
         of the pipeline. The Otsu threshold works by creating a histogram of the hue
@@ -57,13 +58,8 @@ class MarchingSquares:
         between these two peaks. The output of this function is a binary valued
         segmented image 0 for sea and 1 for land
         """
-        if self.image is None:
-            raise ValueError(
-                f"Cannot calculate Otsu segmentation when self.image is None."
-            )
-
-        hue_channel = self.image[:, :, 0]
-        self.threshold, self.result_image = cv2.threshold(
+        hue_channel = image[:, :, 0]
+        return cv2.threshold(
             hue_channel,
             0,
             1,

--- a/marching_squares/marching_squares/marching_squares.py
+++ b/marching_squares/marching_squares/marching_squares.py
@@ -211,7 +211,8 @@ class MarchingSquares:
 
         return [x for x in vectors if x is not None]  # filtering None values
 
-    def _vector_shapes(self) -> None:
+    @staticmethod
+    def _vector_shapes(vectors: list[list[_VECTOR]]) -> list[list[_POINT]]:
         """The purpose of this funciton is to connect all adjacent vector lines to
         create one long "coastline vector". This is done by creating a set of the
         vector lines from the previous function. The first in this set is popped out
@@ -228,16 +229,14 @@ class MarchingSquares:
         size. The main coastline vector will be the longest whereas there will be
         shorter vectors corresponding to islands.
         """
-        if self.vectors is None:
-            raise ValueError(f"Cannot connect vectors if self.vectors is None.")
 
         shapes: list[list[_POINT]] = []
-        vectors_to_remove: set[int] = set(range(len(self.vectors)))
+        vectors_to_remove: set[int] = set(range(len(vectors)))
         while vectors_to_remove:
             shape: list[_POINT] = []
 
             # Get the first vector and extract the tuple of points
-            vector: _VECTOR = self.vectors[vectors_to_remove.pop()][0]
+            vector: _VECTOR = vectors[vectors_to_remove.pop()][0]
 
             start_point: _POINT
             end_point: _POINT
@@ -256,7 +255,7 @@ class MarchingSquares:
 
                 for idx in list(vectors_to_remove):
 
-                    vec: _VECTOR = self.vectors[idx][0]
+                    vec: _VECTOR = vectors[idx][0]
 
                     # Check if the vector connects to the shape
                     if vec[0] == end_point:
@@ -292,7 +291,7 @@ class MarchingSquares:
 
             shapes.append(shape)
 
-        self.shapes = sorted(shapes, key=lambda shape: len(shape), reverse=True)
+        return sorted(shapes, key=lambda shape: len(shape), reverse=True)
 
     def _show_coastline(self) -> None:
         """This is the plotting function that will plot the main coastline vector. The

--- a/marching_squares/marching_squares/marching_squares.py
+++ b/marching_squares/marching_squares/marching_squares.py
@@ -66,7 +66,8 @@ class MarchingSquares:
             cv2.THRESH_BINARY + cv2.THRESH_OTSU,
         )
 
-    def _sort_key(self, point: _POINT) -> int:
+    @staticmethod
+    def _sort_key(point: _POINT) -> int:
         """Creating a function that will weight the dictionary points such that they
         can be sorted from left to right starting at the bottom left.
         """

--- a/marching_squares/marching_squares/marching_squares.py
+++ b/marching_squares/marching_squares/marching_squares.py
@@ -74,7 +74,7 @@ class MarchingSquares:
         return point[1] * 100 + point[0]
 
     @staticmethod
-    def _point_array(image: _NUMERIC_ARRAY) -> tuple[dict[tuple[_POINT, bool]], int, int]:
+    def _point_array(image: _NUMERIC_ARRAY) -> tuple[dict[_POINT, bool], int, int]:
         """This extracts the points from the image and stores them in a dictionary with
         each point either corresponding to black or white. The coordinates are doubled
         and incresed by one as vector lines will be drawn halfway between these points.
@@ -325,14 +325,8 @@ class MarchingSquares:
     def run(file: str, downsample_factor: float = 1) -> None:
         
         image = MarchingSquares._readfile(file, downsample_factor)
-        _, image = MarchingSquares._otsu_segmentation(image)
-        state_dict, x_len, y_len = MarchingSquares._point_array(image)
+        _, threshold_image = MarchingSquares._otsu_segmentation(image)
+        state_dict, x_len, y_len = MarchingSquares._point_array(threshold_image)
         vectors = MarchingSquares._list_vectors(state_dict, x_len, y_len)
         shapes = MarchingSquares._vector_shapes(vectors)
         _ = MarchingSquares._show_coastline(image, shapes, x_len, y_len)
-
-
-import os
-
-print(os.path.dirname(__file__) + "/Aberdeenshire_S2_20220810_TCI.tif")
-MarchingSquares.run(os.path.dirname(__file__) + "/Aberdeenshire_S2_20220810_TCI.tif")

--- a/marching_squares/marching_squares/marching_squares.py
+++ b/marching_squares/marching_squares/marching_squares.py
@@ -12,21 +12,6 @@ _VECTOR = tuple[_POINT, _POINT]
 
 
 class MarchingSquares:
-    def __init__(self, filename: str, downsample_factor: float) -> None:
-        self.filename = filename
-        self.downsample_factor = downsample_factor
-        self._reset_state
-
-    def _reset_state(self) -> None:
-        self.image: Optional[_NUMERIC_ARRAY] = None
-        self.result_image: Optional[_NUMERIC_ARRAY] = None
-        self.threshold: Optional[float] = None
-        self.state_dict: Optional[dict[_POINT, bool]] = None
-        self.x_len: Optional[int] = None
-        self.y_len: Optional[int] = None
-        self.vectors: Optional[list[list[_VECTOR]]] = None
-        self.shapes: Optional[list[list[_POINT]]] = None
-        self.coastline_vector: Optional[list[_POINT]] = None
 
     @staticmethod
     def _readfile(filename: str, downsample_factor: float) -> _NUMERIC_ARRAY:

--- a/marching_squares/marching_squares/marching_squares.py
+++ b/marching_squares/marching_squares/marching_squares.py
@@ -28,23 +28,24 @@ class MarchingSquares:
         self.shapes: Optional[list[list[_POINT]]] = None
         self.coastline_vector: Optional[list[_POINT]] = None
 
-    def _readfile(self) -> None:
+    @staticmethod
+    def _readfile(filename: str, downsample_factor: float) -> _NUMERIC_ARRAY:
         """Reads a tif file with bgr formatting, resizes the image if necessary and
         then converts into a hsv file using the cv2 library.
         """
-        image_bgr = cv2.imread(self.filename)
+        image_bgr = cv2.imread(filename)
 
         # If necessary for performance speed, compress the file
         new_size: _POINT = (
-            int(image_bgr.shape[0] * self.downsample_factor),
-            int(image_bgr.shape[1] * self.downsample_factor),
+            int(image_bgr.shape[0] * downsample_factor),
+            int(image_bgr.shape[1] * downsample_factor),
         )
         image_resized = cv2.resize(image_bgr, new_size, interpolation=cv2.INTER_AREA)
 
         # For the chosen segmentation method it has been decided to segment
         # the image using the hue channel of a converted hsv image to
         # distinguish between land and sea.
-        self.image = cv2.cvtColor(image_resized, cv2.COLOR_BGR2HSV)
+        return cv2.cvtColor(image_resized, cv2.COLOR_BGR2HSV)
 
     def _otsu_segmentation(self) -> None:
         """Uses the Otsu segmentation method to distinguish between land and sea to

--- a/marching_squares/marching_squares/marching_squares.py
+++ b/marching_squares/marching_squares/marching_squares.py
@@ -336,3 +336,6 @@ class MarchingSquares:
         vectors = MarchingSquares._list_vectors(state_dict, x_len, y_len)
         shapes = MarchingSquares._vector_shapes(vectors)
         _ = MarchingSquares._show_coastline(image, shapes, x_len, y_len)
+
+
+MarchingSquares.run("marching_squares/marching_squares/Aberdeenshire_S2_20220810_TCI.tif", 0.05)

--- a/marching_squares/marching_squares/marching_squares.py
+++ b/marching_squares/marching_squares/marching_squares.py
@@ -187,32 +187,29 @@ class MarchingSquares:
 
         return vector
 
-    def _list_vectors(self) -> None:
-        if self.y_len is None:
-            raise ValueError("Cannot list vectors when self.y_len is None.")
-        if self.x_len is None:
-            raise ValueError("Cannot list vectors when self.x_len is None.")
+    @staticmethod
+    def _list_vectors(state_dict: dict[_POINT, bool], x_len: int, y_len: int) -> list[list[_VECTOR]]:
 
         vectors: list[list[_VECTOR] | None] = []
         i: int
         j: int
-        for j in range(1, self.y_len, 2):
+        for j in range(1, y_len, 2):
 
-            for i in range(1, self.x_len, 2):
+            for i in range(1, x_len, 2):
 
-                index: int = self._get_value(i, j)
+                index: int = MarchingSquares._get_value(state_dict, i, j)
 
                 if index == 6 or index == 9:
 
-                    double_vec: list[_VECTOR] | None = self._generate_edges(i, j, index)
+                    double_vec: list[_VECTOR] | None = MarchingSquares._generate_edges(i, j, index)
                     if double_vec:
                         vectors.append([double_vec[0]])
                         vectors.append([double_vec[1]])
 
                 else:
-                    vectors.append(self._generate_edges(i, j, index))
+                    vectors.append(MarchingSquares._generate_edges(i, j, index))
 
-        self.vectors = [x for x in vectors if x is not None]  # filtering None values
+        return [x for x in vectors if x is not None]  # filtering None values
 
     def _vector_shapes(self) -> None:
         """The purpose of this funciton is to connect all adjacent vector lines to

--- a/marching_squares/marching_squares/marching_squares.py
+++ b/marching_squares/marching_squares/marching_squares.py
@@ -112,7 +112,8 @@ class MarchingSquares:
 
         return (dict(sorted_dict),  max(xblack + xwhite), max(yblack + ywhite))
 
-    def _get_value(self, i: int, j: int) -> int:
+    @staticmethod
+    def _get_value(state_dict: dict[_POINT, bool], i: int, j: int) -> int:
         """Splitting the point array space into squares 1 pixel wide. These squares
         have corners lying on either a black or white point. The square as a whole
         adopts a value through the marching squares method, for a square centred at
@@ -123,15 +124,11 @@ class MarchingSquares:
         15. Each of these values coresponds to a line shape which will be used to
         create a coastline vector.
         """
-        if self.state_dict is None:
-            raise ValueError(
-                "Cannot calculate index self.state_dict when self.state_dict is None"
-            )
 
-        A = int(self.state_dict[(i, j)])
-        B = int(self.state_dict[(i + 2, j)])
-        C = int(self.state_dict[(i, j + 2)])
-        D = int(self.state_dict[(i + 2, j + 2)])
+        A = int(state_dict[(i, j)])
+        B = int(state_dict[(i + 2, j)])
+        C = int(state_dict[(i, j + 2)])
+        D = int(state_dict[(i + 2, j + 2)])
         return A + B * 2 + C * 4 + D * 8
 
     def _generate_edges(self, i: int, j: int, index: int) -> list[_VECTOR] | None:

--- a/marching_squares/marching_squares/marching_squares.py
+++ b/marching_squares/marching_squares/marching_squares.py
@@ -293,36 +293,33 @@ class MarchingSquares:
 
         return sorted(shapes, key=lambda shape: len(shape), reverse=True)
 
-    def _show_coastline(self) -> None:
+    @staticmethod
+    def _show_coastline(image: _NUMERIC_ARRAY, shapes: list[list[_POINT]], x_len: int, y_len: int) -> list[_POINT]:
         """This is the plotting function that will plot the main coastline vector. The
         range of the for loop can be changed to plot any islands as well.
         """
-        if self.shapes is None:
-            raise ValueError("Cannot show coastline when self.shapes is None.")
-        if self.image is None:
-            raise ValueError("Cannot show coastline when self.image is None.")
 
         plt.figure(figsize=(10, 5))
         plt.subplot(1, 2, 1)
         plt.title("Coastline Vector Extracted")
         for i in range(1):
-            coastline_vector: list[_POINT] = self.shapes[i]
+            coastline_vector: list[_POINT] = shapes[i]
             xcoords: list[int] = []
             ycoords: list[int] = []
             for point in coastline_vector:
                 xcoords.append(point[0])
                 ycoords.append(point[1])
             plt.plot(xcoords, ycoords, linewidth=1)
-        plt.xlim((0, self.x_len))
-        plt.ylim((0, self.y_len))
+        plt.xlim((0, x_len))
+        plt.ylim((0, y_len))
 
         plt.subplot(1, 2, 2)
         plt.title("Original Image")
-        plt.imshow(cv2.cvtColor(self.image, cv2.COLOR_HSV2RGB))
+        plt.imshow(cv2.cvtColor(image, cv2.COLOR_HSV2RGB))
         plt.axis("off")
 
         plt.show()
-        self.coastline_vector = self.shapes[0]
+        return shapes[0]
 
     def run(self, file: str) -> None:
         self.file = file

--- a/marching_squares/marching_squares/marching_squares.py
+++ b/marching_squares/marching_squares/marching_squares.py
@@ -110,7 +110,7 @@ class MarchingSquares:
             state.items(), key=lambda x: MarchingSquares._sort_key(x[0])
         )
 
-        return (dict(sorted_dict),  max(xblack + xwhite), max(yblack + ywhite))
+        return (dict(sorted_dict), max(xblack + xwhite), max(yblack + ywhite))
 
     @staticmethod
     def _get_value(state_dict: dict[_POINT, bool], i: int, j: int) -> int:
@@ -188,7 +188,9 @@ class MarchingSquares:
         return vector
 
     @staticmethod
-    def _list_vectors(state_dict: dict[_POINT, bool], x_len: int, y_len: int) -> list[list[_VECTOR]]:
+    def _list_vectors(
+        state_dict: dict[_POINT, bool], x_len: int, y_len: int
+    ) -> list[list[_VECTOR]]:
 
         vectors: list[list[_VECTOR] | None] = []
         i: int
@@ -201,7 +203,9 @@ class MarchingSquares:
 
                 if index == 6 or index == 9:
 
-                    double_vec: list[_VECTOR] | None = MarchingSquares._generate_edges(i, j, index)
+                    double_vec: list[_VECTOR] | None = MarchingSquares._generate_edges(
+                        i, j, index
+                    )
                     if double_vec:
                         vectors.append([double_vec[0]])
                         vectors.append([double_vec[1]])
@@ -294,7 +298,9 @@ class MarchingSquares:
         return sorted(shapes, key=lambda shape: len(shape), reverse=True)
 
     @staticmethod
-    def _show_coastline(image: _NUMERIC_ARRAY, shapes: list[list[_POINT]], x_len: int, y_len: int) -> list[_POINT]:
+    def _show_coastline(
+        image: _NUMERIC_ARRAY, shapes: list[list[_POINT]], x_len: int, y_len: int
+    ) -> list[_POINT]:
         """This is the plotting function that will plot the main coastline vector. The
         range of the for loop can be changed to plot any islands as well.
         """
@@ -323,7 +329,7 @@ class MarchingSquares:
 
     @staticmethod
     def run(file: str, downsample_factor: float = 1) -> None:
-        
+
         image = MarchingSquares._readfile(file, downsample_factor)
         _, threshold_image = MarchingSquares._otsu_segmentation(image)
         state_dict, x_len, y_len = MarchingSquares._point_array(threshold_image)

--- a/marching_squares/marching_squares/test_marching_squares.py
+++ b/marching_squares/marching_squares/test_marching_squares.py
@@ -11,6 +11,11 @@ _RANDOM_IMAGE = np.random.uniform(low=0, high=256, size=_IMAGE_SHAPE).astype(np.
 class MarchingSquaresTests(unittest.TestCase):
 
     def test_no_runtime_errors(self) -> None:
+        """
+        This test does not verify the logic of the MarchingSquares classe, but verifies
+        that it at least does not crash. This ensures that the code on main is runnable
+        at all times.
+        """
         fd, path = mkstemp()
         with os.fdopen(fd, "wb") as file:
             image = Image.fromarray(_RANDOM_IMAGE, "RGB")

--- a/marching_squares/marching_squares/test_marching_squares.py
+++ b/marching_squares/marching_squares/test_marching_squares.py
@@ -1,0 +1,22 @@
+import os
+import unittest
+from PIL import Image
+from tempfile import mkstemp
+import numpy as np
+from marching_squares import MarchingSquares
+
+_IMAGE_SHAPE = (512, 512, 4)
+_RANDOM_IMAGE = np.random.uniform(low=0, high=256, size=_IMAGE_SHAPE).astype(np.uint8)
+
+class MarchingSquaresTests(unittest.TestCase):
+
+    def test_no_runtime_errors(self) -> None:
+        fd, path = mkstemp()
+        with os.fdopen(fd, "wb") as file:
+            image = Image.fromarray(_RANDOM_IMAGE, "RGB")
+            image.save(file, format="TIFF")
+        MarchingSquares.run(path, 0.05)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/marching_squares/marching_squares/test_marching_squares.py
+++ b/marching_squares/marching_squares/test_marching_squares.py
@@ -8,6 +8,7 @@ from marching_squares import MarchingSquares
 _IMAGE_SHAPE = (512, 512, 4)
 _RANDOM_IMAGE = np.random.uniform(low=0, high=256, size=_IMAGE_SHAPE).astype(np.uint8)
 
+
 class MarchingSquaresTests(unittest.TestCase):
 
     def test_no_runtime_errors(self) -> None:


### PR DESCRIPTION
## Overview

This PR refactors the `MarchingSquares` class to be a stateless utility class, because the state contained in the old `MarchingSquares` objects was discarded.

## Changes

- added `test_marching_squares.py` to run a unit test on the `marching_squares.py` module. This will ensure that whenever changes are merged into main, the module runs correctly. It does not check the logic, just that no runtime errors pop up.
- refactored the `MarchingSquares` class to be stateless

## Testing

1. `git checkout bf2f3432701c21fb97057ac547380194e1d8958a` to go to the test commit
2. run `marching_squares.py`. The test commit will run marching squares. The output produced is as expected.

Output from my test run:
<img width="1002" alt="Screenshot 2024-12-01 at 20 49 17" src="https://github.com/user-attachments/assets/0375f233-1b3c-48cf-a1fd-6bc07c683375">

## Additional Information

1. Noticed that the constant variables in `test_cloud_mask.py` are not signified as private with an underscore (`_`) prefix. Should probably update that.
2. We could use some updates to the CI pipeline. Now that we're incorporating c++ code, it might make more sense to put all our python code in one subdirectory and the c++ code in another, so that the pipeline is simpler to call (just search the python / c++ directory for the right files instead of jumping into the multiple directories with relevant code). Not sure what the industry standard recommendation is, though, my only professional experience was in code that was naturally segmented by language because one logical section would all be in the same language.
4. WRT CI pipeline, PR and issue templates could be improve. #45 #46 

Closes #34 